### PR TITLE
イベント編集・削除機能

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -32,6 +32,12 @@ class EventsController < ApplicationController
     end
   end
 
+  def destroy
+    @event = current_user.created_events.find(params[:id])
+    @event.destroy!
+    redirect_to root_path, notice: "削除しました"
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,17 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
   end
 
+  def edit
+    @event = current_user.created_events.find(params[:id])
+  end
+
+  def update
+    @event = current_user.created_events.find(params[:id])
+    if @event.update(event_params)
+      redirect_to @event, notice: "更新しました"
+    end
+  end
+
   private
 
   def event_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,11 @@ class Event < ApplicationRecord
   validates :end_at, presence: true
   validate :start_at_should_be_before_end_at
   
+  def created_by?(user)
+    return false unless user
+    owner_id == user.id
+  end
+
   private
 
   def start_at_should_be_before_end_at

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -1,0 +1,24 @@
+- now = Time.zone.now
+
+%h1.mt-2 イベント情報編集
+
+= form_with(model: @event, class: "form-horizontal") do |f|
+  #errors
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: "form-control"
+  .form-group
+    = f.label :place
+    = f.text_field :place, class: "form-control"
+  .form-group
+    = f.label :start_at
+    %div
+      = f.datetime_select :start_at, start_year: now.year, end_year: now.year + 1
+  .form-group
+    = f.label :end_at
+    %div
+      = f.datetime_select :end_at, start_year: now.year, end_year: now.year + 1
+  .form-group
+    = f.label :content
+    = f.text_area :content, class: "form-control", row: 10
+  = f.submit class: "btn btn-primary"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -22,3 +22,4 @@
   .col-4
     - if @event.created_by?(current_user)
       = link_to "イベントを編集する", edit_event_path(@event), class: "btn btn-info btn-lg btn-block"
+      = link_to "イベントを削除する", event_path(@event), class: "btn btn-danger btn-lg btn-block", method: :delete, data: { confirm: "本当に削除しますか？" }

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,19 +1,24 @@
 %h1.mt-3.mb-3= @event.name
-.card.mb-2
-  %h5.card-header イベント内容
-  .card-body
-    %p.card-text= @event.content
-.card.mb-2
-  %h5.card-header 開催日時
-  .card-body
-    %p.card-text= "#{l(@event.start_at, format: :long)} - #{l(@event.end_at, format: :long)}"
-.card.mb-2
-  %h5.card-header 開催場所
-  .card-body
-    %p.card-text= @event.place
-.card.mb-2
-  %h5.card-header イベント主催者
-  .card-body
-    = link_to("https://github.com/#{@event.owner.name}", class: "card-link") do
-      = image_tag @event.owner.image_url, width: 50, height: 50, style: "border-radius: 50%"
-      = "@#{@event.owner.name}"
+.row
+  .col-8
+    .card.mb-2
+      %h5.card-header イベント内容
+      .card-body
+        %p.card-text= @event.content
+    .card.mb-2
+      %h5.card-header 開催日時
+      .card-body
+        %p.card-text= "#{l(@event.start_at, format: :long)} - #{l(@event.end_at, format: :long)}"
+    .card.mb-2
+      %h5.card-header 開催場所
+      .card-body
+        %p.card-text= @event.place
+    .card.mb-2
+      %h5.card-header イベント主催者
+      .card-body
+        = link_to("https://github.com/#{@event.owner.name}", class: "card-link") do
+          = image_tag @event.owner.image_url, width: 50, height: 50, style: "border-radius: 50%"
+          = "@#{@event.owner.name}"
+  .col-4
+    - if @event.created_by?(current_user)
+      = link_to "イベントを編集する", edit_event_path(@event), class: "btn btn-info btn-lg btn-block"

--- a/app/views/events/update.js.erb
+++ b/app/views/events/update.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("errors").innerHTML = "<%= j render("errors", errors: @event.errors) %>"


### PR DESCRIPTION
# what
- イベント編集機能の実装
  - イベント詳細ページにイベントを編集するリンクを追加
  - イベントを作成したユーザがアクセスした時だけ表示
  - イベントを編集するボタンをクリックすると編集画面に遷移
  - 正しく入力すると更新
- イベント削除機能の実装
  - イベント詳細ページにイベントを削除するリンクを追加
  - イベントを作成したユーザがアクセスした時だけ表示
  - 削除ボタンをクリックすると確認ダイアログが表示、OKでイベント削除